### PR TITLE
支持按间隔更新CK；增加自动重试

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 #### Version 2022-02-02 新年快乐
 ---
+**2022年2月5日 02:55:26**
+- **支持按间隔更新CK 参数 `export WSKEY_UPDATE_HOUR="间隔（单位：小时）" `**
+- **增加自动重试 参数 `export WSKEY_TRY_COUNT="次数" `**
+
+---
 **2022年2月2日 22:46:26**
 - **serch_ck方法优化**
 - **调整UA为最新10.3.5参数**
@@ -20,7 +25,6 @@
 - **更新10.3.5接口**
 - **新增`WSKEY_AUTO_DISABLE`变量 设置后不会自动禁用Cookie**
 - **移除部分冗余代码**
-- **感谢 `@Xeath` 的建议**
 
 ---
 **2022年1月22日 11:19:41**
@@ -188,6 +192,11 @@
 # 设置 QL_WSCK变量后 不检查有效性 直接更新 不使用请删除 而不是禁用
 变量名: WSKEY_AUTO_DISABLE 参数: 任意(str)	
 # 设置 WSKEY_AUTO_DISABLE变量后 不会自动禁用变量
+变量名: WSKEY_UPDATE_HOUR 参数: 整数(int) 单位：小时
+# 设置 WSKEY_UPDATE_HOUR 变量后 会按设定的间隔时间更新 CK
+# 注意：使用此参数后，即使 CK 过期也不会更新，请不要设置过大的间隔
+变量名: WSKEY_TRY_COUNT 参数: 整数(int)
+# 设置 WSKEY_TRY_COUNT 变量后 获取 Token 失败会自动重试
 ```
 ---
 

--- a/wskey.py
+++ b/wskey.py
@@ -9,6 +9,7 @@ import os
 import sys
 import logging
 import time
+import re
 
 if "WSKEY_DEBUG" in os.environ:
     logging.basicConfig(level=logging.DEBUG, format='%(message)s')
@@ -123,7 +124,30 @@ def get_ck():
 
 # 返回值 bool
 def check_ck(ck):
-    if "QL_WSCK" in os.environ:
+    searchObj = re.search(r'pt_pin=([^;\s]+)', ck, re.M|re.I)
+    if searchObj:
+        pin = searchObj.group(1)
+    else:
+        pin = ck.split(";")[1]
+    if "WSKEY_UPDATE_HOUR" in os.environ:
+        updateHour = 23
+        if os.environ["WSKEY_UPDATE_HOUR"].isdigit():
+            updateHour = int(os.environ["WSKEY_UPDATE_HOUR"])
+        nowTime = time.time()
+        updatedAt = 0.0
+        searchObj = re.search(r'__time=([^;\s]+)', ck, re.M|re.I)
+        if searchObj:
+            updatedAt = float(searchObj.group(1))
+        if nowTime - updatedAt >= (updateHour * 60 * 60) - (10 * 60):
+            logger.info(str(pin) + ";即将到期或已过期\n")
+            return False
+        else:
+            remainingTime = (updateHour * 60 * 60) - (nowTime - updatedAt)
+            hour = int(remainingTime / 60 / 60)
+            minute = int((remainingTime % 3600) / 60)
+            logger.info(str(pin) + ";未到期，{0}时{1}分后更新\n".format(hour, minute))
+            return True
+    elif "QL_WSCK" in os.environ:
         logger.info("不检查账号有效性\n--------------------\n")
         return False
     else:
@@ -142,7 +166,6 @@ def check_ck(ck):
         else:
             if res.status_code == 200:
                 code = int(json.loads(res.text)['retcode'])
-                pin = ck.split(";")[1]
                 if code == 0:
                     logger.info(str(pin) + ";状态正常\n")
                     return True
@@ -212,7 +235,7 @@ def appjmp(wskey, tokenKey):
             res_set = res.cookies.get_dict()
             pt_key = 'pt_key=' + res_set['pt_key']
             pt_pin = 'pt_pin=' + res_set['pt_pin']
-            jd_ck = str(pt_key) + ';' + str(pt_pin) + ';'
+            jd_ck = str(pt_key) + '; ' + str(pt_pin) + '; __time=' + str(time.time())
         except Exception as err:
             logger.info("JD_appjmp提取Cookie错误 请重试或者更换IP\n")
             logger.info(str(err))
@@ -427,6 +450,7 @@ if __name__ == '__main__':
     ua = cloud_arg['User-Agent']
     wslist = get_wskey()
     envlist = get_env()
+    sleepTime = 10
     for ws in wslist:
         wspin = ws.split(";")[0]
         if "pin" in wspin:
@@ -435,7 +459,17 @@ if __name__ == '__main__':
             if return_serch[0]:  # bool: True 搜索到账号
                 jck = str(return_serch[1])  # 拿到 JD_COOKIE
                 if not check_ck(jck):  # bool: False 判定 JD_COOKIE 有效性
-                    return_ws = getToken(ws)  # 使用 WSKEY 请求获取 JD_COOKIE bool jd_ck
+                    tryCount = 1
+                    if "WSKEY_TRY_COUNT" in os.environ:
+                        if os.environ["WSKEY_TRY_COUNT"].isdigit():
+                            tryCount = int(os.environ["WSKEY_TRY_COUNT"])
+                    for count in range(1, tryCount):
+                        return_ws = getToken(ws)  # 使用 WSKEY 请求获取 JD_COOKIE bool jd_ck
+                        if return_ws[0]:
+                            break
+                        if count < tryCount:
+                            logger.info("{0} 秒后重试，剩余次数：{1}\n".format(sleepTime, tryCount - count))
+                            time.sleep(sleepTime)
                     if return_ws[0]:  # bool: True
                         nt_key = str(return_ws[1])
                         # logger.info("wskey转pt_key成功", nt_key)
@@ -468,6 +502,8 @@ if __name__ == '__main__':
                     nt_key = str(return_ws[1])
                     logger.info("wskey转换成功\n")
                     ql_insert(nt_key)
+            logger.info("暂停{0}秒\n".format(sleepTime))
+            time.sleep(sleepTime)
         else:
             logger.info("WSKEY格式错误\n--------------------\n")
     logger.info("执行完成\n--------------------")

--- a/wskey.py
+++ b/wskey.py
@@ -463,7 +463,8 @@ if __name__ == '__main__':
                     if "WSKEY_TRY_COUNT" in os.environ:
                         if os.environ["WSKEY_TRY_COUNT"].isdigit():
                             tryCount = int(os.environ["WSKEY_TRY_COUNT"])
-                    for count in range(1, tryCount):
+                    for count in range(tryCount):
+                        count += 1
                         return_ws = getToken(ws)  # 使用 WSKEY 请求获取 JD_COOKIE bool jd_ck
                         if return_ws[0]:
                             break


### PR DESCRIPTION
- **支持按间隔更新CK 参数 `export WSKEY_UPDATE_HOUR="间隔（单位：时）" `**
- **增加自动重试 参数 `export WSKEY_TRY_COUNT="次数" `**

凌晨来提交个 PR，已经在 2.11.0 和 2.11.2 进行了完整测试。
如果 CK 中不存在 `__time`，启用 `WSKEY_UPDATE_HOUR` 后执行 `wskey.py` 则会立刻更新；移除了 `updatedAt`，因为这个非常不靠谱，`wskey.py` 的启用账户似乎会导致 `updatedAt` 产生变化，进而导致永远不更新账户，而且移除后也可以减少修改到 @Zy143L 的代码。

请求新的 CK 并不会导致上一个 CK 过期，这样可以用间隔更新的方法尽量保持 CK 有效（虽然我自己遇到过上午抓的 app_open 下午就失效的情况），不过这里还是会有例外，比如任务的运行时间非常长，并且刚好账户在最后面，以及刚好快过期，那么轮到这个账户的时候如果失效了也是非常正常。

当然也可以通过修改计划任务的时间为每隔 12 个小时或者 16 个小时，但是如果发生意料之外的事情（例如没有请求到 `sign`，或者 `getToken` 超时之类），导致没有更新上，那么就变成有 24 小时或者 32 小时的空窗期，如果这期间过期，即使搭配 sendNotify 或者 task_after.sh 还是少运行了 1 次，这样感觉少了灵魂不符合 `打造生态化薅豆`，毕竟用户还是会感知到 CK 已失效。

![截屏2022-02-05 上午2.38.58](https://user-images.githubusercontent.com/28760483/152587015-b3a5a602-b57e-4975-964a-06c25a3cc1d9.png)
![截屏2022-02-05 上午2 40 38](https://user-images.githubusercontent.com/28760483/152587024-6b3d7d7e-9220-4c8c-b52c-077296fcc571.png)

在 2.11.0 中删去 `WSKEY_UPDATE_HOUR` 后会正常使用原有逻辑（即检查 CK 状态）

![截屏2022-02-05 上午2 45 17](https://user-images.githubusercontent.com/28760483/152587029-a2c3d3c5-eaf0-4f32-b7ed-a73687e803ba.png)

最后感谢 @Zy143L 的辛勤付出。